### PR TITLE
[DRAFT] Sherlock: Fix for incorrect prefunding calculation in claimProceeds

### DIFF
--- a/src/modules/Auction.sol
+++ b/src/modules/Auction.sol
@@ -196,14 +196,13 @@ abstract contract Auction {
     ///             - Validate the lot parameters
     ///             - Update the lot data
     ///
-    /// @param      lotId_          The lot id
-    /// @return     purchased       The amount of quote tokens purchased
-    /// @return     sold            The amount of base tokens sold
-    /// @return     payoutSent      The amount of base tokens that have already been paid out
+    /// @param      lotId_                  The lot id
+    /// @return     purchased               The amount of quote tokens purchased
+    /// @return     amountOutToClaim        The amount of base tokens to be claimed
     function claimProceeds(uint96 lotId_)
         external
         virtual
-        returns (uint96 purchased, uint96 sold, uint96 payoutSent);
+        returns (uint96 purchased, uint96 amountOutToClaim);
 
     // ========== AUCTION MANAGEMENT ========== //
 
@@ -642,7 +641,7 @@ abstract contract AuctionModule is Auction, Module {
         virtual
         override
         onlyInternal
-        returns (uint96 purchased, uint96 sold, uint96 payoutSent)
+        returns (uint96 purchased, uint96 amountOutToClaim)
     {
         // Standard validation
         _revertIfLotInvalid(lotId_);
@@ -657,14 +656,13 @@ abstract contract AuctionModule is Auction, Module {
     /// @dev        Auction modules should override this to perform any additional logic,
     ///             such as updating the lot data
     ///
-    /// @param      lotId_          The lot ID
-    /// @return     purchased       The amount of quote tokens purchased
-    /// @return     sold            The amount of base tokens sold
-    /// @return     payoutSent      The amount of base tokens that have already been paid out
+    /// @param      lotId_                  The lot ID
+    /// @return     purchased               The amount of quote tokens purchased
+    /// @return     amountOutToClaim        The amount of base tokens to be claimed
     function _claimProceeds(uint96 lotId_)
         internal
         virtual
-        returns (uint96 purchased, uint96 sold, uint96 payoutSent);
+        returns (uint96 purchased, uint96 amountOutToClaim);
 
     // ========== AUCTION INFORMATION ========== //
 

--- a/src/modules/auctions/FPAM.sol
+++ b/src/modules/auctions/FPAM.sol
@@ -174,7 +174,7 @@ contract FixedPriceAuctionModule is AuctionModule {
         revert Auction_NotImplemented();
     }
 
-    function _claimProceeds(uint96) internal pure override returns (uint96, uint96, uint96) {
+    function _claimProceeds(uint96) internal pure override returns (uint96, uint96) {
         revert Auction_NotImplemented();
     }
 

--- a/test/AuctionHouse/claimProceeds.t.sol
+++ b/test/AuctionHouse/claimProceeds.t.sol
@@ -168,20 +168,6 @@ contract ClaimProceedsTest is AuctionHouseTest {
         uint96 payout_
     ) {
         _mockClaimBid(bidder_, referrer_, amountIn_, payout_);
-
-        // // Calculate fees
-        // (uint256 toReferrer, uint256 toProtocol) = _calculateFees(referrer_, amountIn_);
-        // _expectedReferrerFee += toReferrer;
-        // _expectedProtocolFee += toProtocol;
-
-        // // Set expected balances
-        // _expectedAuctionHouseQuoteTokenBalance += amountIn_; // Payment to be collected in claimProceeds()
-        // _expectedBidderQuoteTokenBalance += 0;
-
-        // _expectedAuctionHouseBaseTokenBalance -= payout_; // To be collected in claimProceeds()
-        // _expectedBidderBaseTokenBalance += bidder_ == _bidder ? payout_ : 0;
-        // _expectedBidderTwoBaseTokenBalance += bidder_ == _BIDDER_TWO ? payout_ : 0;
-        // _expectedCuratorBaseTokenBalance += 0;
         _;
     }
 

--- a/test/modules/Auction/MockAtomicAuctionModule.sol
+++ b/test/modules/Auction/MockAtomicAuctionModule.sol
@@ -103,11 +103,11 @@ contract MockAtomicAuctionModule is AuctionModule {
         revert Auction_NotImplemented();
     }
 
-    function claimProceeds(uint96) external pure override returns (uint96, uint96, uint96) {
+    function claimProceeds(uint96) external pure override returns (uint96, uint96) {
         revert Auction_NotImplemented();
     }
 
-    function _claimProceeds(uint96) internal pure override returns (uint96, uint96, uint96) {
+    function _claimProceeds(uint96) internal pure override returns (uint96, uint96) {
         revert Auction_NotImplemented();
     }
 

--- a/test/modules/Auction/MockAuctionModule.sol
+++ b/test/modules/Auction/MockAuctionModule.sol
@@ -47,7 +47,7 @@ contract MockAuctionModule is AuctionModule {
 
     function _settle(uint96 lotId_) internal override returns (Settlement memory, bytes memory) {}
 
-    function _claimProceeds(uint96 lotId_) internal override returns (uint96, uint96, uint96) {}
+    function _claimProceeds(uint96 lotId_) internal override returns (uint96, uint96) {}
 
     function _refundBid(
         uint96 lotId_,

--- a/test/modules/Auction/MockBatchAuctionModule.sol
+++ b/test/modules/Auction/MockBatchAuctionModule.sol
@@ -42,6 +42,8 @@ contract MockBatchAuctionModule is AuctionModule {
 
     mapping(uint96 => bool) public settled;
 
+    mapping(uint96 => uint96) public bidsToBeClaimed;
+
     constructor(address _owner) AuctionModule(_owner) {
         minAuctionDuration = 1 days;
     }
@@ -133,6 +135,8 @@ contract MockBatchAuctionModule is AuctionModule {
         lot.purchased = uint96(settlement_.totalIn);
         lot.sold = uint96(settlement_.totalOut);
         lot.partialPayout = uint96(settlement_.pfPayout);
+
+        bidsToBeClaimed[lotId_] = lot.sold - lot.partialPayout;
     }
 
     function _settle(uint96 lotId_) internal override returns (Settlement memory, bytes memory) {
@@ -142,12 +146,12 @@ contract MockBatchAuctionModule is AuctionModule {
         return (lotSettlements[lotId_], "");
     }
 
-    function _claimProceeds(uint96 lotId_) internal override returns (uint96, uint96, uint96) {
+    function _claimProceeds(uint96 lotId_) internal override returns (uint96, uint96) {
         // Update status
         lotStatus[lotId_] = Auction.Status.Claimed;
 
         Lot storage lot = lotData[lotId_];
-        return (lot.purchased, lot.sold, lot.partialPayout);
+        return (lot.purchased, bidsToBeClaimed[lotId_]);
     }
 
     function getBid(uint96 lotId_, uint64 bidId_) external view returns (Bid memory bid_) {

--- a/test/modules/auctions/EMPA/EMPAModuleTest.sol
+++ b/test/modules/auctions/EMPA/EMPAModuleTest.sol
@@ -377,7 +377,8 @@ abstract contract EmpaModuleTest is Test, Permit2User {
             Auction.Status status_,
             uint64 marginalBidId_,
             Point memory publicKey_,
-            uint256 privateKey_
+            uint256 privateKey_,
+            uint96 amountOutToClaim_
         ) = _module.auctionData(lotId_);
 
         return EncryptedMarginalPriceAuctionModule.AuctionData({
@@ -391,7 +392,8 @@ abstract contract EmpaModuleTest is Test, Permit2User {
             marginalBidId: marginalBidId_,
             publicKey: publicKey_,
             privateKey: privateKey_,
-            bidIds: new uint64[](0)
+            bidIds: new uint64[](0),
+            amountOutToClaim: amountOutToClaim_
         });
     }
 

--- a/test/modules/auctions/EMPA/claimBids.t.sol
+++ b/test/modules/auctions/EMPA/claimBids.t.sol
@@ -228,6 +228,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_unsuccessfulBid_fuzz(uint96 bidAmountIn_)
@@ -274,6 +278,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_unsuccessfulBid_quoteTokenDecimalsLarger()
@@ -319,6 +327,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_unsuccessfulBid_quoteTokenDecimalsSmaller()
@@ -364,6 +376,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid()
@@ -405,6 +421,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_quoteTokenDecimalsLarger()
@@ -450,6 +470,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_quoteTokenDecimalsSmaller()
@@ -495,6 +519,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_marginalPriceRounding()
@@ -541,6 +569,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_marginalPriceRounding_capacityExceeded()
@@ -598,6 +630,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(
             uint8(bidThree.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed)
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_amountIn_fuzz(uint96 bidAmountIn_)
@@ -651,6 +687,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_successfulBid_amountOut_fuzz(uint96 bidAmountOut_)
@@ -705,6 +745,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_mixtureBids()
@@ -748,6 +792,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(uint8(bidOne.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
         EncryptedMarginalPriceAuctionModule.Bid memory bidTwo = _getBid(_lotId, _bidIds[1]);
         assertEq(uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed));
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, 0, "amountOutToClaim");
     }
 
     function test_unclaimedBids()
@@ -790,6 +838,10 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         assertEq(
             uint8(bidTwo.status), uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Decrypted)
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(auctionData.amountOutToClaim, _scaleBaseTokenAmount(5e18), "amountOutToClaim");
     }
 
     function test_givenLotOverCapacity_higherMarginalPrice()
@@ -832,6 +884,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 3),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_higherMarginalPrice_beforeLastSettledBid()
@@ -849,9 +909,9 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         givenLotIsSettled
     {
         // Marginal price is 2
-        // Bids 1, 3-5 are settled
-        // Bid 2 is not settled (based on order of insertion)
-        uint64 bidId = 4;
+        // Bids 1-4 are settled
+        // Bid 5 is not settled (based on order of insertion)
+        uint64 bidId = 3;
 
         uint64[] memory bidIds = new uint64[](1);
         bidIds[0] = bidId;
@@ -873,6 +933,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(bid.status),
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
+        );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_FOUR_AMOUNT_OUT * 2 + _BID_PRICE_TWO_AMOUNT_OUT * 2),
+            "amountOutToClaim"
         );
     }
 
@@ -916,6 +984,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_FOUR_AMOUNT_OUT * 2 + _BID_PRICE_TWO_AMOUNT_OUT * 2),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_higherMarginalPrice_afterLastSettledBid()
@@ -958,6 +1034,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_FOUR_AMOUNT_OUT * 2 + _BID_PRICE_TWO_AMOUNT_OUT * 3),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_sameMarginalPrice_beforeLastSettledBid()
@@ -978,7 +1062,7 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         // Marginal price is 2
         // Bids 1-5 are settled
         // Bid 6 is not settled (based on order of insertion)
-        uint64 bidId = 5;
+        uint64 bidId = 4;
 
         uint64[] memory bidIds = new uint64[](1);
         bidIds[0] = bidId;
@@ -1000,6 +1084,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(bid.status),
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
+        );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 4),
+            "amountOutToClaim"
         );
     }
 
@@ -1044,6 +1136,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 4),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_sameMarginalPrice_afterSettledBid()
@@ -1087,6 +1187,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 5),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_unsuccessfulBid()
@@ -1105,6 +1213,8 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         givenLotIsDecrypted
         givenLotIsSettled
     {
+        // Bids 1-5 successful
+        // Bids 6-7 unsuccessful
         uint64 bidId = 7;
 
         uint64[] memory bidIds = new uint64[](1);
@@ -1128,6 +1238,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
         );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 5),
+            "amountOutToClaim"
+        );
     }
 
     function test_givenLotOverCapacity_unsuccessfulBid_respectsOrdering()
@@ -1146,6 +1264,8 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
         givenLotIsDecrypted
         givenLotIsSettled
     {
+        // Bids 2-5 successful
+        // Bids 1, 7 unsuccessful
         uint64 bidId = 1;
 
         uint64[] memory bidIds = new uint64[](1);
@@ -1168,6 +1288,14 @@ contract EmpaModuleClaimBidsTest is EmpaModuleTest {
             uint8(bid.status),
             uint8(EncryptedMarginalPriceAuctionModule.BidStatus.Claimed),
             "status"
+        );
+
+        // Check the auction data
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(
+            auctionData.amountOutToClaim,
+            _scaleBaseTokenAmount(_BID_PRICE_TWO_AMOUNT_OUT * 5),
+            "amountOutToClaim"
         );
     }
 }

--- a/test/modules/auctions/EMPA/claimProceeds.t.sol
+++ b/test/modules/auctions/EMPA/claimProceeds.t.sol
@@ -207,12 +207,11 @@ contract EmpaModuleClaimProceedsTest is EmpaModuleTest {
     {
         // Call function
         vm.prank(address(_auctionHouse));
-        (uint256 purchased, uint256 sold, uint256 partialPayout) = _module.claimProceeds(_lotId);
+        (uint256 purchased, uint256 amountOutToClaim) = _module.claimProceeds(_lotId);
 
         // Assert values
         assertEq(purchased, _expectedPurchased);
-        assertEq(sold, _expectedSold);
-        assertEq(partialPayout, _expectedPartialPayout);
+        assertEq(amountOutToClaim, _expectedSold - _expectedPartialPayout);
     }
 
     function test_givenLotIsUnderCapacity()
@@ -227,11 +226,10 @@ contract EmpaModuleClaimProceedsTest is EmpaModuleTest {
     {
         // Call function
         vm.prank(address(_auctionHouse));
-        (uint256 purchased, uint256 sold, uint256 partialPayout) = _module.claimProceeds(_lotId);
+        (uint256 purchased, uint256 amountOutToClaim) = _module.claimProceeds(_lotId);
 
         // Assert values
         assertEq(purchased, _expectedPurchased);
-        assertEq(sold, _expectedSold);
-        assertEq(partialPayout, _expectedPartialPayout);
+        assertEq(amountOutToClaim, _expectedSold);
     }
 }

--- a/test/modules/auctions/EMPA/settle.t.sol
+++ b/test/modules/auctions/EMPA/settle.t.sol
@@ -126,6 +126,7 @@ contract EmpaModuleSettleTest is EmpaModuleTest {
 
         EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
         assertEq(auctionData.marginalBidId, _expectedMarginalBidId, "marginalBidId");
+        assertEq(auctionData.amountOutToClaim, _expectedTotalOut - _expectedPartialFillPayout, "amountOutToClaim");
     }
 
     function _assertLot() internal {


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2024-03-axis-finance-judging/issues/187

Issue: the prefunding calc in `claimProceeds()` did not take into account whether the bids had been claimed. If bids were claimed beyond a certain threshold, `routing.funding` would underflow.

There were a few approaches that could be taken to solving this:
- track the original capacity of an auction lot and reconstruct the non-bid payout amount
- track the amount of bid payouts remaining

It seemed easier to track the bid payouts remaining.