### PR TITLE
Sherlock: Claim bids after claim proceeds

### DIFF
--- a/src/modules/Auction.sol
+++ b/src/modules/Auction.sol
@@ -36,8 +36,7 @@ abstract contract Auction {
     enum Status {
         Created,
         Decrypted,
-        Settled,
-        Claimed
+        Settled
     }
 
     /// @notice     Core data for an auction lot

--- a/src/modules/auctions/EMPAM.sol
+++ b/src/modules/auctions/EMPAM.sol
@@ -59,10 +59,15 @@ contract EncryptedMarginalPriceAuctionModule is AuctionModule {
 
     /// @notice        Struct containing auction-specific data
     ///
-    /// @param         status              The status of the auction
     /// @param         nextBidId           The ID of the next bid to be submitted
-    /// @param         nextDecryptIndex    The index of the next bid to decrypt
     /// @param         marginalPrice       The marginal price of the auction (determined at settlement, blank before)
+    /// @param         minPrice            The minimum price that the auction will settle at
+    /// @param         nextDecryptIndex    The index of the next bid to decrypt
+    /// @param         minFilled           The minimum amount of the lot that must be filled
+    /// @param         minBidSize          The minimum size of a bid
+    /// @param         status              The status of the auction
+    /// @param         proceedsClaimed     Whether the proceeds have been claimed
+    /// @param         marginalBidId       The ID of the marginal bid (marking that bids following it are not filled)
     /// @param         publicKey           The public key used to encrypt bids (a point on the alt_bn128 curve from the generator point (1,2))
     /// @param         privateKey          The private key used to decrypt bids (not provided until after the auction ends)
     /// @param         bidIds              The list of bid IDs to decrypt in order of submission, excluding cancelled bids
@@ -74,7 +79,8 @@ contract EncryptedMarginalPriceAuctionModule is AuctionModule {
         uint96 minFilled; // 12 +
         uint96 minBidSize; // 12 = 32 - end of slot 2
         Auction.Status status; // 1 +
-        uint64 marginalBidId; // 8 = 9 - end of slot 3
+        bool proceedsClaimed; // 1 +
+        uint64 marginalBidId; // 8 = 10 - end of slot 3
         Point publicKey; // 64 - slots 4 and 5
         uint256 privateKey; // 32 - slot 6
         uint64[] bidIds; // slots 7+
@@ -203,8 +209,9 @@ contract EncryptedMarginalPriceAuctionModule is AuctionModule {
         // Batch auctions cannot be cancelled once started, otherwise the seller could cancel the auction after bids have been submitted
         _revertIfLotActive(lotId_);
 
-        // Set auction status to claimed so that bids can be refunded
-        auctionData[lotId_].status = Auction.Status.Claimed;
+        // Set auction status to settled so that bids can be refunded
+        auctionData[lotId_].status = Auction.Status.Settled;
+        auctionData[lotId_].proceedsClaimed = true;
     }
 
     // ========== BID ========== //
@@ -843,7 +850,7 @@ contract EncryptedMarginalPriceAuctionModule is AuctionModule {
         returns (uint96 purchased, uint96 sold, uint96 payoutSent)
     {
         // Update the status
-        auctionData[lotId_].status = Auction.Status.Claimed;
+        auctionData[lotId_].proceedsClaimed = true;
 
         // Get the lot data
         Lot memory lot = lotData[lotId_];
@@ -909,7 +916,7 @@ contract EncryptedMarginalPriceAuctionModule is AuctionModule {
     /// @inheritdoc AuctionModule
     function _revertIfLotProceedsClaimed(uint96 lotId_) internal view override {
         // Auction must not have proceeds claimed
-        if (auctionData[lotId_].status == Auction.Status.Claimed) {
+        if (auctionData[lotId_].proceedsClaimed == true) {
             revert Auction_WrongState(lotId_);
         }
     }

--- a/test/AuctionHouse/claimProceeds.t.sol
+++ b/test/AuctionHouse/claimProceeds.t.sol
@@ -69,7 +69,7 @@ contract ClaimProceedsTest is AuctionHouseTest {
         assertEq(lotRouting.funding, funding, "funding");
 
         // Check the lot status
-        assertEq(uint8(_batchAuctionModule.lotStatus(_lotId)), uint8(Auction.Status.Claimed));
+        assertEq(uint8(_batchAuctionModule.lotStatus(_lotId)), uint8(Auction.Status.Settled));
     }
 
     // ============ Modifiers ============ //

--- a/test/modules/Auction/MockBatchAuctionModule.sol
+++ b/test/modules/Auction/MockBatchAuctionModule.sol
@@ -39,6 +39,7 @@ contract MockBatchAuctionModule is AuctionModule {
     mapping(uint96 lotId => Settlement) public lotSettlements;
 
     mapping(uint96 lotId => Auction.Status) public lotStatus;
+    mapping(uint96 lotId => bool) public lotProceedsClaimed;
 
     mapping(uint96 => bool) public settled;
 
@@ -144,7 +145,8 @@ contract MockBatchAuctionModule is AuctionModule {
 
     function _claimProceeds(uint96 lotId_) internal override returns (uint96, uint96, uint96) {
         // Update status
-        lotStatus[lotId_] = Auction.Status.Claimed;
+        lotStatus[lotId_] = Auction.Status.Settled;
+        lotProceedsClaimed[lotId_] = true;
 
         Lot storage lot = lotData[lotId_];
         return (lot.purchased, lot.sold, lot.partialPayout);
@@ -195,7 +197,7 @@ contract MockBatchAuctionModule is AuctionModule {
 
     function _revertIfLotProceedsClaimed(uint96 lotId_) internal view virtual override {
         // Check that the lot has not been claimed
-        if (lotStatus[lotId_] == Auction.Status.Claimed) {
+        if (lotProceedsClaimed[lotId_] == true) {
             revert Auction.Auction_InvalidParams();
         }
     }

--- a/test/modules/auctions/EMPA/EMPAModuleTest.sol
+++ b/test/modules/auctions/EMPA/EMPAModuleTest.sol
@@ -375,6 +375,7 @@ abstract contract EmpaModuleTest is Test, Permit2User {
             uint96 minFilled_,
             uint96 minBidSize_,
             Auction.Status status_,
+            bool proceedsClaimed_,
             uint64 marginalBidId_,
             Point memory publicKey_,
             uint256 privateKey_
@@ -388,6 +389,7 @@ abstract contract EmpaModuleTest is Test, Permit2User {
             minFilled: minFilled_,
             minBidSize: minBidSize_,
             status: status_,
+            proceedsClaimed: proceedsClaimed_,
             marginalBidId: marginalBidId_,
             publicKey: publicKey_,
             privateKey: privateKey_,

--- a/test/modules/auctions/EMPA/cancelAuction.t.sol
+++ b/test/modules/auctions/EMPA/cancelAuction.t.sol
@@ -73,10 +73,11 @@ contract EmpaModuleCancelAuctionTest is EmpaModuleTest {
 
         // Check the state
         Auction.Lot memory lotData = _getAuctionLot(_lotId);
-        assertEq(lotData.conclusion, uint48(block.timestamp));
-        assertEq(lotData.capacity, 0);
+        assertEq(lotData.conclusion, uint48(block.timestamp), "conclusion");
+        assertEq(lotData.capacity, 0, "capacity");
 
         EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
-        assertEq(uint8(auctionData.status), uint8(Auction.Status.Claimed));
+        assertEq(uint8(auctionData.status), uint8(Auction.Status.Settled), "status");
+        assertEq(auctionData.proceedsClaimed, true, "proceedsClaimed");
     }
 }

--- a/test/modules/auctions/EMPA/claimProceeds.t.sol
+++ b/test/modules/auctions/EMPA/claimProceeds.t.sol
@@ -210,9 +210,14 @@ contract EmpaModuleClaimProceedsTest is EmpaModuleTest {
         (uint256 purchased, uint256 sold, uint256 partialPayout) = _module.claimProceeds(_lotId);
 
         // Assert values
-        assertEq(purchased, _expectedPurchased);
-        assertEq(sold, _expectedSold);
-        assertEq(partialPayout, _expectedPartialPayout);
+        assertEq(purchased, _expectedPurchased, "purchased");
+        assertEq(sold, _expectedSold, "sold");
+        assertEq(partialPayout, _expectedPartialPayout, "partialPayout");
+
+        // Assert auction status
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(uint8(auctionData.status), uint8(Auction.Status.Settled), "status");
+        assertEq(auctionData.proceedsClaimed, true, "proceedsClaimed");
     }
 
     function test_givenLotIsUnderCapacity()
@@ -230,8 +235,13 @@ contract EmpaModuleClaimProceedsTest is EmpaModuleTest {
         (uint256 purchased, uint256 sold, uint256 partialPayout) = _module.claimProceeds(_lotId);
 
         // Assert values
-        assertEq(purchased, _expectedPurchased);
-        assertEq(sold, _expectedSold);
-        assertEq(partialPayout, _expectedPartialPayout);
+        assertEq(purchased, _expectedPurchased, "purchased");
+        assertEq(sold, _expectedSold, "sold");
+        assertEq(partialPayout, _expectedPartialPayout, "partialPayout");
+
+        // Assert auction status
+        EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData = _getAuctionData(_lotId);
+        assertEq(uint8(auctionData.status), uint8(Auction.Status.Settled), "status");
+        assertEq(auctionData.proceedsClaimed, true, "proceedsClaimed");
     }
 }

--- a/test/modules/derivatives/LinearVestingEMPAIntegration.t.sol
+++ b/test/modules/derivatives/LinearVestingEMPAIntegration.t.sol
@@ -210,7 +210,8 @@ contract LinearVestingEMPAIntegrationTest is AuctionHouseTest {
         // Check the auction data
         EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData =
             _empaModule.getAuctionData(_lotId);
-        assertEq(uint8(auctionData.status), uint8(Auction.Status.Claimed), "status");
+        assertEq(uint8(auctionData.status), uint8(Auction.Status.Settled), "status");
+        assertEq(auctionData.proceedsClaimed, true, "proceedsClaimed");
 
         // Check balances
         assertEq(_baseToken.balanceOf(_SELLER), _LOT_CAPACITY, "seller balance");
@@ -523,7 +524,8 @@ contract LinearVestingEMPAIntegrationTest is AuctionHouseTest {
         // Check the auction state
         EncryptedMarginalPriceAuctionModule.AuctionData memory auctionData =
             _empaModule.getAuctionData(_lotId);
-        assertEq(uint8(auctionData.status), uint8(Auction.Status.Claimed), "status");
+        assertEq(uint8(auctionData.status), uint8(Auction.Status.Settled), "status");
+        assertEq(auctionData.proceedsClaimed, true, "proceedsClaimed");
 
         // Check the balances
         assertEq(_quoteToken.balanceOf(_SELLER), _BID_AMOUNT, "seller balance");


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2024-03-axis-finance-judging/issues/67

Instead of adjusting the _revertIfNotSettled() virtual function, I decided that the "Claimed" auction status did not make sense, since the status is normally a mutually-exclusive state, which "Claimed" is not. That was also the cause of the problem!