### PR TITLE
fix: remove check preventing seller from being referrer

### DIFF
--- a/src/AtomicAuctionHouse.sol
+++ b/src/AtomicAuctionHouse.sol
@@ -117,7 +117,6 @@ contract AtomicAuctionHouse is IAtomicAuctionHouse, AuctionHouse {
                 lotFees[params_.lotId].protocolFee,
                 lotFees[params_.lotId].referrerFee,
                 params_.referrer,
-                routing.seller,
                 ERC20(routing.quoteToken),
                 params_.amount
             );

--- a/src/BatchAuctionHouse.sol
+++ b/src/BatchAuctionHouse.sol
@@ -324,7 +324,6 @@ contract BatchAuctionHouse is IBatchAuctionHouse, AuctionHouse {
                     protocolFee,
                     referrerFee,
                     bidClaim.referrer,
-                    routing.seller,
                     quoteToken,
                     bidClaim.paid - bidClaim.refund // refund is included in paid
                 );

--- a/src/bases/AuctionHouse.sol
+++ b/src/bases/AuctionHouse.sol
@@ -606,21 +606,18 @@ abstract contract AuctionHouse is IAuctionHouse, WithModules, ReentrancyGuard, F
     /// @param   protocolFee_   The fee charged by the protocol
     /// @param   referrerFee_   The fee charged by the referrer
     /// @param   referrer_      The address of the referrer
-    /// @param   seller_        The address of the seller
     /// @param   quoteToken_    The quote token
     /// @param   amount_        The amount of quote tokens
     function _allocateQuoteFees(
         uint48 protocolFee_,
         uint48 referrerFee_,
         address referrer_,
-        address seller_,
         ERC20 quoteToken_,
         uint256 amount_
     ) internal returns (uint256 totalFees) {
         // Calculate fees for purchase
-        (uint256 toReferrer, uint256 toProtocol) = calculateQuoteFees(
-            protocolFee_, referrerFee_, referrer_ != address(0) && referrer_ != seller_, amount_
-        );
+        (uint256 toReferrer, uint256 toProtocol) =
+            calculateQuoteFees(protocolFee_, referrerFee_, referrer_ != address(0), amount_);
 
         // Update fee balances if non-zero
         if (toReferrer > 0) rewards[referrer_][quoteToken_] += toReferrer;


### PR DESCRIPTION
Allows the seller to be a referrer so that they don't pay referrer fees when they are directing users to their own auction. 

They still will have to claim the fees like any other referrer because the batch auction logic depends on each bid having a consistent referrer fee across all bids.