### PR TITLE
Version Skipping

### DIFF
--- a/src/AtomicAuctionHouse.sol
+++ b/src/AtomicAuctionHouse.sol
@@ -46,6 +46,13 @@ contract AtomicAuctionHouse is IAtomicAuctionHouse, AuctionHouse {
         address permit2_
     ) AuctionHouse(owner_, protocol_, permit2_) {}
 
+    // ========== VERSIONING ========== //
+
+    /// @inheritdoc IAuctionHouse
+    function VERSION() external pure returns (uint8 major, uint8 minor) {
+        return (1, 1);
+    }
+
     // ========== AUCTION MANAGEMENT ========== //
 
     /// @inheritdoc AuctionHouse

--- a/src/BatchAuctionHouse.sol
+++ b/src/BatchAuctionHouse.sol
@@ -53,6 +53,13 @@ contract BatchAuctionHouse is IBatchAuctionHouse, AuctionHouse {
         address permit2_
     ) AuctionHouse(owner_, protocol_, permit2_) {}
 
+    // ========== VERSIONING ========== //
+
+    /// @inheritdoc IAuctionHouse
+    function VERSION() external pure returns (uint8 major, uint8 minor) {
+        return (1, 1);
+    }
+
     // ========== AUCTION MANAGEMENT ========== //
 
     /// @inheritdoc AuctionHouse

--- a/src/interfaces/IAuctionHouse.sol
+++ b/src/interfaces/IAuctionHouse.sol
@@ -115,6 +115,11 @@ interface IAuctionHouse {
         uint48 referrerFee; // 6 bytes
     }
 
+    // ========== VERSIONING ========== //
+
+    /// @notice     The version of the AuctionHouse
+    function VERSION() external view returns (uint8 major, uint8 minor);
+
     // ========== AUCTION MANAGEMENT ========== //
 
     /// @notice     Creates a new auction lot

--- a/src/modules/Modules.sol
+++ b/src/modules/Modules.sol
@@ -63,7 +63,7 @@ abstract contract WithModules is Owned {
     /// @dev        - The module is not a contract
     /// @dev        - The module has an invalid Veecode
     /// @dev        - The module (or other versions) is already installed
-    /// @dev        - The module version is not one greater than the latest version
+    /// @dev        - The module version is not greater than the latest version
     ///
     /// @param      newModule_  The new module
     function installModule(
@@ -75,9 +75,10 @@ abstract contract WithModules is Owned {
         ensureValidVeecode(veecode);
         (Keycode keycode, uint8 version) = unwrapVeecode(veecode);
 
-        // Validate that the module version is one greater than the latest version
+        // Validate that the module version is greater than the latest version
         ModStatus storage status = getModuleStatus[keycode];
-        if (version != status.latestVersion + 1) revert InvalidModuleInstall(keycode, version);
+        uint8 currentVersion = status.latestVersion;
+        if (version <= currentVersion) revert InvalidModuleInstall(keycode, version);
 
         // Store module data and remove sunset if applied
         status.latestVersion = version;
@@ -85,7 +86,7 @@ abstract contract WithModules is Owned {
         getModuleForVeecode[veecode] = newModule_;
 
         // If the module is not already installed, add it to the list of modules
-        if (version == uint8(1)) {
+        if (currentVersion == uint8(0)) {
             modules.push(keycode);
             modulesCount++;
         }


### PR DESCRIPTION
- Allows for modules to skip versions (e.g. initial version is 3 instead of 1)
- Adds `VERSION()` function to `AuctionHouse`

I'm unsure if we would want to re-deploy, given the skip versioning is not a huge issue, but I wanted this to be around in case.